### PR TITLE
Fixed version number of ZMTP v3.1

### DIFF
--- a/spec_37.txt
+++ b/spec_37.txt
@@ -86,7 +86,7 @@ padding = 8OCTET        ; Not significant
 
 version = version-major version-minor
 version-major = %x03
-version-minor = %x00
+version-minor = %x01
 
 ;   The mechanism is a null padded string
 mechanism = 20mechanism-char
@@ -135,7 +135,7 @@ In either case, note that:
 
 * A peer SHALL NOT assign any significance to the padding field and MUST NOT validate this nor interpret it in any way whatsoever.
 
-* A peer MUST accept higher protocol versions as valid. That is, a ZMTP peer MUST accept protocol versions greater or equal to 3.0. This allows future implementations to safely interoperate with current implementations.
+* A peer MUST accept higher protocol versions as valid. That is, a ZMTP peer MUST accept protocol versions greater or equal to 3.1. This allows future implementations to safely interoperate with current implementations.
 
 * A peer SHALL always use its own protocol (including framing) when talking to an equal or higher protocol peer.
 
@@ -469,9 +469,9 @@ From [[http://rfc.zeromq.org/spec:13 ZMTP 2.0] onwards, the protocol contains th
 
 * If the peer version number is 1 or 2, the peer is using ZMTP 2.0, so send the ZMTP 2.0 socket type and identity and continue with ZMTP 2.0.
 
-* If the peer version number is 3 or higher, the peer is using ZMTP 3.0, so send the rest of the greeting and continue with ZMTP 3.0.
+* If the peer version number is 3 or higher, the peer is using ZMTP 3.x, so send the rest of the greeting and continue with ZMTP 3.1 or 3.0.
 
-Here is the sequence of commands showing two ZMTP 3.0 peers using this algorithm:
+Here is the sequence of commands showing two ZMTP 3.1 peers using this algorithm:
 
 [[code]]
 C:signature + major-version             S:signature + major-version
@@ -492,13 +492,13 @@ C:message...                            S:message...
 
 * If this first octet is %FF, then we read nine further octets, and inspect the last octet (the 10th in total). If the least significant bit is 0, then the other peer is using ZMTP 1.0 and has sent us a long length for its identity. We read that many octets.
 
-* If the least significant bit is 1, the peer is using ZMTP 2.0 or later and has sent us the ZMTP signature. We read a further octet, which indicates the ZMTP version. If this is 1 or 2, we have a ZMTP 2.0 peer. If this is 3, we have a ZMTP 3.0 peer.
+* If the least significant bit is 1, the peer is using ZMTP 2.0 or later and has sent us the ZMTP signature. We read a further octet, which indicates the ZMTP version. If this is 1 or 2, we have a ZMTP 2.0 peer. If this is 3, we have a ZMTP 3.x peer.
 
 * When we have detected a ZMTP 1.0 peer, we have already sent 10 octets, which the other peer interprets as the start of an identity frame. We continue by sending the body of the identity frame (zero or more octets). From then, we encode and decode all frames on that connection using the ZMTP 1.0 framing syntax.
 
 * When we have detected a ZMTP 2.0 peer, we continue with version negotiation as explained above, by sending our version number and then socket type and identity as defined by the ZMTP 2.0 specification.
 
-* When we have detected a ZMTP 3.0 peer, we continue by sending the remainder of the greeting (octets 10-64) and then continue with the security handshake as normal.
+* When we have detected a ZMTP 3.x peer, we continue by sending the remainder of the greeting (octets 10-64) and then continue with the security handshake as normal.
 
 ++ Worked Example
 


### PR DESCRIPTION
- was still defined as 3.0 in grammar and text
