### PR TITLE
Tighten public contract documentation requirement.

### DIFF
--- a/spec_22.txt
+++ b/spec_22.txt
@@ -134,7 +134,7 @@ C4 is meant to provide a reusable optimal collaboration model for open source so
 
 +++ Evolution of Public Contracts
 
-* All Public Contracts (APIs or protocols) SHOULD be documented.
+* All Public Contracts (APIs or protocols) SHALL be documented.
 
 * All Public Contracts SHOULD have space for extensibility and experimentation.
 


### PR DESCRIPTION
Currently, C4 merely recommends that public contracts be documented.  However,
for my project's needs, I need this to be a hard requirement.  This PR alters
the text accordingly.