### PR TITLE
Problem: referring to rules of C4 is difficult

### DIFF
--- a/spec_42.txt
+++ b/spec_42.txt
@@ -18,149 +18,95 @@ You should have received a copy of the GNU General Public License along with thi
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [http://tools.ietf.org/html/rfc2119 RFC 2119].
 
-++ Goals
+++ 1. Goals
 
 C4 is meant to provide a reusable optimal collaboration model for open source software projects. It has these specific goals:
 
-* To maximize the scale and diversity of the community around a project, by reducing the friction for new Contributors and creating a scaled participation model with strong positive feedbacks;
-
-* To relieve dependencies on key individuals by separating different skill sets so that there is a larger pool of competence in any required domain;
-
-* To allow the project to develop faster and more accurately, by increasing the diversity of the decision making process;
-
-* To support the natural life cycle of project versions from experimental through to stable, by allowing safe experimentation, rapid failure, and isolation of stable code;
-
-* To reduce the internal complexity of project repositories, thus making it easier for Contributors to participate and reducing the scope for error;
-
-* To enforce collective ownership of the project, which increases economic incentive to Contributors and reduces the risk of hijack by hostile entities.
-
-++ Design
-
-+++ Preliminaries
-
-* The project SHALL use the git distributed revision control system.
-
-* The project SHALL be hosted on github.com or equivalent, herein called the "Platform".
-
-* The project SHALL use the Platform issue tracker.
-
-* The project SHOULD have clearly documented guidelines for code style.
-
-* A "Contributor" is a person who wishes to provide a patch, being a set of commits that solve some clearly identified problem.
-
-* A "Maintainer" is a person who merges patches to the project. Maintainers are not developers; their job is to enforce process.
-
-* Contributors SHALL NOT have commit access to the repository unless they are also Maintainers.
-
-* Maintainers SHALL have commit access to the repository.
-
-* Everyone, without distinction or discrimination, SHALL have an equal right to become a Contributor under the terms of this contract.
-
-+++ Licensing and Ownership
-
-* The project SHALL use a share-alike license such as the MPLv2, or a GPLv3 variant thereof (GPL, LGPL, AGPL).
-
-* All contributions to the project source code ("patches") SHALL use the same license as the project.
-
-* All patches are owned by their authors. There SHALL NOT be any copyright assignment process.
-
-* Each Contributor SHALL be responsible for identifying themselves in the project Contributor list.
-
-+++ Patch Requirements
-
-* Maintainers and Contributors MUST have a Platform account and SHOULD use their real names or a well-known alias.
-
-* A patch SHOULD be a minimal and accurate answer to exactly one identified and agreed problem.
-
-* A patch MUST adhere to the code style guidelines of the project if these are defined.
-
-* A patch MUST adhere to the "Evolution of Public Contracts" guidelines defined below.
-
-* A patch SHALL NOT include non-trivial code from other projects unless the Contributor is the original author of that code.
-
-* A patch MUST compile cleanly and pass project self-tests on at least the principle target platform.
-
-* A patch commit message MUST consist of a single short (less than 50 characters) line stating the problem ("Problem: ...") being solved, followed by a blank line and then the proposed solution ("Solution: ...").
-
-* A "Correct Patch" is one that satisfies the above requirements.
-
-+++ Development Process
-
-* Change on the project SHALL be governed by the pattern of accurately identifying problems and applying minimal, accurate solutions to these problems.
-
-* To request changes, a user SHOULD log an issue on the project Platform issue tracker.
-
-* The user or Contributor SHOULD write the issue by describing the problem they face or observe.
-
-* The user or Contributor SHOULD seek consensus on the accuracy of their observation, and the value of solving the problem.
-
-* Users SHALL NOT log feature requests, ideas, suggestions, or any solutions to problems that are not explicitly documented and provable.
-
-* Thus, the release history of the project SHALL be a list of meaningful issues logged and solved.
-
-* To work on an issue, a Contributor SHALL fork the project repository and then work on their forked repository.
-
-* To submit a patch, a Contributor SHALL create a Platform pull request back to the project.
-
-* A Contributor SHALL NOT commit changes directly to the project.
-
-* If the Platform implements pull requests as issues, a Contributor MAY directly send a pull request without logging a separate issue.
-
-* To discuss a patch, people MAY comment on the Platform pull request, on the commit, or elsewhere.
-
-* To accept or reject a patch, a Maintainer SHALL use the Platform interface.
-
-* Maintainers SHOULD NOT merge their own patches except in exceptional cases, such as non-responsiveness from other Maintainers for an extended period (more than 1-2 days).
-
-* Maintainers SHALL NOT make value judgments on correct patches.
-
-* Maintainers SHALL merge correct patches from other Contributors rapidly.
-
-* Maintainers MAY merge incorrect patches from other Contributors with the goals of (a) ending fruitless discussions, (b) capturing toxic patches in the historical record, (c) engaging with the Contributor on improving their patch quality.
-
-* The user who created an issue SHOULD close the issue after checking the patch is successful.
-
-* Any Contributor who has value judgments on a patch SHOULD express these via their own patches.
-
-* Maintainers SHOULD close user issues that are left open without action for an uncomfortable period of time.
-
-+++ Branches and Releases
-
-* The project SHALL have one branch ("master") that always holds the latest in-progress version and SHOULD always build.
-
-* The project SHALL NOT use topic branches for any reason. Personal forks MAY use topic branches.
-
-* To make a stable release a Maintainer shall tag the repository. Stable releases SHALL always be released from the repository master.
-
-+++ Evolution of Public Contracts
-
-* All Public Contracts (APIs or protocols) SHALL be documented.
-
-* All Public Contracts SHOULD have space for extensibility and experimentation.
-
-* A patch that modifies a stable Public Contract SHOULD not break existing applications unless there is overriding consensus on the value of doing this.
-
-* A patch that introduces new features SHOULD do so using new names (a new contract).
-
-* New contracts SHOULD be marked as "draft" until they are stable and used by real users.
-
-* Old contracts SHOULD be deprecated in a systematic fashion by marking them as "deprecated" and replacing them with new contracts as needed.
-
-* When sufficient time has passed, old deprecated contracts SHOULD be removed.
-
-* Old names SHALL NOT be reused by new contracts.
-
-+++ Project Administration
-
-* The project founders SHALL act as Administrators to manage the set of project Maintainers.
-
-* The Administrators SHALL ensure their own succession over time by promoting the most effective Maintainers.
-
-* A new Contributor who makes correct patches, who clearly understands the project goals, and the process SHOULD be invited to become a Maintainer.
-
-* Administrators SHOULD remove Maintainers who are inactive for an extended period of time, or who repeatedly fail to apply this process accurately.
-
-* Administrators SHOULD block or ban "bad actors" who cause stress and pain to others in the project. This should be done after public discussion, with a chance for all parties to speak. A bad actor is someone who repeatedly ignores the rules and culture of the project, who is needlessly argumentative or hostile, or who is offensive, and who is unable to self-correct their behavior when asked to do so by others.
+# To maximize the scale and diversity of the community around a project, by reducing the friction for new Contributors and creating a scaled participation model with strong positive feedbacks;
+# To relieve dependencies on key individuals by separating different skill sets so that there is a larger pool of competence in any required domain;
+# To allow the project to develop faster and more accurately, by increasing the diversity of the decision making process;
+# To support the natural life cycle of project versions from experimental through to stable, by allowing safe experimentation, rapid failure, and isolation of stable code;
+# To reduce the internal complexity of project repositories, thus making it easier for Contributors to participate and reducing the scope for error;
+# To enforce collective ownership of the project, which increases economic incentive to Contributors and reduces the risk of hijack by hostile entities.
+
+++ 2. Design
+
++++ 2.1. Preliminaries
+
+# The project SHALL use the git distributed revision control system.
+# The project SHALL be hosted on github.com or equivalent, herein called the "Platform".
+# The project SHALL use the Platform issue tracker.
+# The project SHOULD have clearly documented guidelines for code style.
+# A "Contributor" is a person who wishes to provide a patch, being a set of commits that solve some clearly identified problem.
+# A "Maintainer" is a person who merges patches to the project. Maintainers are not developers; their job is to enforce process.
+# Contributors SHALL NOT have commit access to the repository unless they are also Maintainers.
+# Maintainers SHALL have commit access to the repository.
+# Everyone, without distinction or discrimination, SHALL have an equal right to become a Contributor under the terms of this contract.
+
++++ 2.2. Licensing and Ownership
+
+# The project SHALL use a share-alike license such as the MPLv2, or a GPLv3 variant thereof (GPL, LGPL, AGPL).
+# All contributions to the project source code ("patches") SHALL use the same license as the project.
+# All patches are owned by their authors. There SHALL NOT be any copyright assignment process.
+# Each Contributor SHALL be responsible for identifying themselves in the project Contributor list.
+
++++ 2.3. Patch Requirements
+
+# Maintainers and Contributors MUST have a Platform account and SHOULD use their real names or a well-known alias.
+# A patch SHOULD be a minimal and accurate answer to exactly one identified and agreed problem.
+# A patch MUST adhere to the code style guidelines of the project if these are defined.
+# A patch MUST adhere to the "Evolution of Public Contracts" guidelines defined below.
+# A patch SHALL NOT include non-trivial code from other projects unless the Contributor is the original author of that code.
+# A patch MUST compile cleanly and pass project self-tests on at least the principle target platform.
+# A patch commit message MUST consist of a single short (less than 50 characters) line stating the problem ("Problem: ...") being solved, followed by a blank line and then the proposed solution ("Solution: ...").
+# A "Correct Patch" is one that satisfies the above requirements.
+
++++ 2.4. Development Process
+
+# Change on the project SHALL be governed by the pattern of accurately identifying problems and applying minimal, accurate solutions to these problems.
+# To request changes, a user SHOULD log an issue on the project Platform issue tracker.
+# The user or Contributor SHOULD write the issue by describing the problem they face or observe.
+# The user or Contributor SHOULD seek consensus on the accuracy of their observation, and the value of solving the problem.
+# Users SHALL NOT log feature requests, ideas, suggestions, or any solutions to problems that are not explicitly documented and provable.
+# Thus, the release history of the project SHALL be a list of meaningful issues logged and solved.
+# To work on an issue, a Contributor SHALL fork the project repository and then work on their forked repository.
+# To submit a patch, a Contributor SHALL create a Platform pull request back to the project.
+# A Contributor SHALL NOT commit changes directly to the project.
+# If the Platform implements pull requests as issues, a Contributor MAY directly send a pull request without logging a separate issue.
+# To discuss a patch, people MAY comment on the Platform pull request, on the commit, or elsewhere.
+# To accept or reject a patch, a Maintainer SHALL use the Platform interface.
+# Maintainers SHOULD NOT merge their own patches except in exceptional cases, such as non-responsiveness from other Maintainers for an extended period (more than 1-2 days).
+# Maintainers SHALL NOT make value judgments on correct patches.
+# Maintainers SHALL merge correct patches from other Contributors rapidly.
+# Maintainers MAY merge incorrect patches from other Contributors with the goals of (a) ending fruitless discussions, (b) capturing toxic patches in the historical record, (c) engaging with the Contributor on improving their patch quality.
+# The user who created an issue SHOULD close the issue after checking the patch is successful.
+# Any Contributor who has value judgments on a patch SHOULD express these via their own patches.
+# Maintainers SHOULD close user issues that are left open without action for an uncomfortable period of time.
+
++++ 2.5. Branches and Releases
+
+# The project SHALL have one branch ("master") that always holds the latest in-progress version and SHOULD always build.
+# The project SHALL NOT use topic branches for any reason. Personal forks MAY use topic branches.
+# To make a stable release a Maintainer shall tag the repository. Stable releases SHALL always be released from the repository master.
+
++++ 2.6. Evolution of Public Contracts
+
+# All Public Contracts (APIs or protocols) SHALL be documented.
+# All Public Contracts SHOULD have space for extensibility and experimentation.
+# A patch that modifies a stable Public Contract SHOULD not break existing applications unless there is overriding consensus on the value of doing this.
+# A patch that introduces new features SHOULD do so using new names (a new contract).
+# New contracts SHOULD be marked as "draft" until they are stable and used by real users.
+# Old contracts SHOULD be deprecated in a systematic fashion by marking them as "deprecated" and replacing them with new contracts as needed.
+# When sufficient time has passed, old deprecated contracts SHOULD be removed.
+# Old names SHALL NOT be reused by new contracts.
+
++++ 2.7. Project Administration
+
+# The project founders SHALL act as Administrators to manage the set of project Maintainers.
+# The Administrators SHALL ensure their own succession over time by promoting the most effective Maintainers.
+# A new Contributor who makes correct patches, who clearly understands the project goals, and the process SHOULD be invited to become a Maintainer.
+# Administrators SHOULD remove Maintainers who are inactive for an extended period of time, or who repeatedly fail to apply this process accurately.
+# Administrators SHOULD block or ban "bad actors" who cause stress and pain to others in the project. This should be done after public discussion, with a chance for all parties to speak. A bad actor is someone who repeatedly ignores the rules and culture of the project, who is needlessly argumentative or hostile, or who is offensive, and who is unable to self-correct their behavior when asked to do so by others.
 
 ++ Further Reading
 


### PR DESCRIPTION
When an particular rule needs to be referred to, it needs to be quoted in full.

Solution: enumerate all "instrumental" sections.

This pull request is done as per a short exchange on Twitter: https://twitter.com/hintjens/status/732678600709812224
