### PR TITLE
Problem: README refers to older C4 as C4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ This is the ZeroMQ RFC project.
 
 We collect specifications for APIs, file formats, wire protocols, and processes.
 
-The change process is C4.1: http://rfc.zeromq.org/spec:22 with a few modifications:
+The change process is C4: http://rfc.zeromq.org/spec:42 with a few modifications:
 
-* A specification is created and modified by pull requests according to C4.1.
+* A specification is created and modified by pull requests according to C4.
 * Each specification has an editor who publishes the RFC to http://rfc.zeromq.org as needed.
 * Each specification has a status on that website: Raw, Draft, Stable, Legacy, Retired, Deleted.
 * Non-cosmetic changes are allowed only on Raw and Draft specifications.


### PR DESCRIPTION
Solution: Update the link and change name from C4.1 to C4