### PR TITLE
Problem: specification metadata can't be accessed programmatically

### DIFF
--- a/1/README.md
+++ b/1/README.md
@@ -1,7 +1,11 @@
-SPB is a minimalist format for framing opaque binary blobs.  The blobs have no properties and no content structure, and are represented as a size field followed by a blob content.
+---
+domain: rfc.zeromq.org
+shortname: 1/SPB
+status: deprecated
+editor: Martin Sustrik <sustrik@imatix.com>
+---
 
-* Name: http://rfc.zeromq.org/spec:1/SPB
-* Editor: Martin Sustrik <sustrik@imatix.com>
+SPB is a minimalist format for framing opaque binary blobs.  The blobs have no properties and no content structure, and are represented as a size field followed by a blob content.
 
 ## License
 
@@ -68,4 +72,3 @@ data    = *OCTET
 ## Reference implementation
 
 A reference implementation for SPB can be found in the [0MQ](http://www.zeromq.org) project.
-

--- a/10/README.md
+++ b/10/README.md
@@ -1,7 +1,12 @@
-The Freelance Protocol (FLP) defines brokerless reliable request-reply dialogs across an N-to-N network of clients and servers. It originated in Chapter 4 of the Guide.
+---
+domain: rfc.zeromq.org
+shortname: 10/FLP
+name: Freelance Protocol
+status: stable
+editor: Pieter Hintjens <ph@imatix.com>
+---
 
-* Name: http://rfc.zeromq.org/spec:10/FLP
-* Editor: Pieter Hintjens <ph@imatix.com>
+The Freelance Protocol (FLP) defines brokerless reliable request-reply dialogs across an N-to-N network of clients and servers. It originated in Chapter 4 of the Guide.
 
 ## License
 
@@ -62,4 +67,3 @@ Server identities are their *public endpoints*. This is the address string that 
 ### Server Reliability
 
 Clients MAY send ping commands at regular intervals. A client SHOULD consider a server "disconnected" if no "pong" arrives within some multiple of that interval (usually 2-3).
-

--- a/11/README.md
+++ b/11/README.md
@@ -1,7 +1,12 @@
-This document proposes a Message Transport Layer (MTL), a connection-oriented protocol that supports broker-based messaging. MTL connects a set of clients with a central message broker, allowing clients to issue commands to the broker, send messages to the broker, and receive messages back from the broker.
+---
+domain: rfc.zeromq.org
+shortname: 11/MTL
+name: Message Transport Layer
+status: draft
+editor: Pieter Hintjens <ph@imatix.com>
+---
 
-* Name: http://rfc.zeromq.org/spec:11/MTL
-* Editor: Pieter Hintjens <ph@imatix.com>
+This document proposes a Message Transport Layer (MTL), a connection-oriented protocol that supports broker-based messaging. MTL connects a set of clients with a central message broker, allowing clients to issue commands to the broker, send messages to the broker, and receive messages back from the broker.
 
 ## License
 
@@ -403,4 +408,3 @@ The server and the client MAY implement the test profile.
 ## Implementations
 
 * https://github.com/imatix/zmetal
-

--- a/12/README.md
+++ b/12/README.md
@@ -1,3 +1,11 @@
+---
+domain: rfc.zeromq.org
+shortname: 12/CHP
+name: Clustered Hashmap Protocol
+status: stable
+editor: Pieter Hintjens <ph@imatix.com>
+---
+
 The Clustered Hashmap Protocol (CHP) defines a cluster-wide key-value hashmap, and mechanisms for sharing this across a set of clients. CHP allows clients to work with subtrees of the hashmap, to update values, and to define ephemeral values. CHP originated from the Clone pattern defined in Chapter 5 of the Guide.
 
 * Name: http://rfc.zeromq.org/spec:12/CHP
@@ -172,4 +180,3 @@ CHP does not implement any authentication, access control, or encryption mechani
 ### Reference Implementations
 
 The C99 Clone examples from Chapter 5 of the Guide (see "[ØMQ - The Guide](http://zguide.zeromq.org)") act as the prime reference implementation for CHP.
-

--- a/13/README.md
+++ b/13/README.md
@@ -1,7 +1,12 @@
-The ZeroMQ Message Transport Protocol (ZMTP) is a transport layer protocol for exchanging messages between two peers over a connected transport layer such as TCP. This document describes ZMTP/1.0 as implemented by the 0MQ/2.x generation of software.
+---
+domain: rfc.zeromq.org
+shortname: 13/ZMTP
+name: ZeroMQ Message Transport Protocol
+status: deprecated
+editor: Pieter Hintjens <ph@imatix.com>
+---
 
-* Name: http://rfc.zeromq.org/spec:13/ZMTP
-* Editor: Pieter Hintjens <ph@imatix.com>
+The ZeroMQ Message Transport Protocol (ZMTP) is a transport layer protocol for exchanging messages between two peers over a connected transport layer such as TCP. This document describes ZMTP/1.0 as implemented by the 0MQ/2.x generation of software.
 
 ## License
 
@@ -228,4 +233,3 @@ The restriction of "identities may not start with a binary zero" is inherited fr
 ## Security
 
 ZMTP/1.0 makes no attempt at security, which an application MAY layer on top.
-

--- a/14/README.md
+++ b/14/README.md
@@ -1,8 +1,12 @@
-Worker-Manager Protocol is a generalization of request-reply pattern, allowing many workers talk to many managers (servers) with intermediate devices and custom load-balancing. **This paper is a rather brief description of protocol, it lacks details and is not complete. I will do my best to finish it and to provide a reference implementation as soon as possible.**
+---
+domain: rfc.zeromq.org
+shortname: 14/WMP
+name: Worker-Manager Protocol
+status: raw
+editor: Brugeman Artur <brugeman.artur@gmail.com>
+---
 
-* Name: http://rfc.zeromq.org/spec:14/WMP
-* Editor: Brugeman Artur <brugeman.artur@gmail.com>
-* Contributors: none yet
+Worker-Manager Protocol is a generalization of request-reply pattern, allowing many workers talk to many managers (servers) with intermediate devices and custom load-balancing. **This paper is a rather brief description of protocol, it lacks details and is not complete. I will do my best to finish it and to provide a reference implementation as soon as possible.**
 
 ## License
 
@@ -97,4 +101,3 @@ All reliability issues, such as jobs timing out, de-duplication of job requests 
 ### Extensions
 
 To extend functionality offered by the protocol, two more commands could be introduced. STATUS - sent by workers to indicate the status of a job. And a CANCEL command, sent by managers, to inform worker that no job result is expected and job processing can be cancelled.
-

--- a/15/README.md
+++ b/15/README.md
@@ -1,8 +1,15 @@
-The ZeroMQ Message Transport Protocol (ZMTP) is a transport layer protocol for exchanging messages between two peers over a connected transport layer such as TCP. This document describes ZMTP/2.0.
+---
+domain: rfc.zeromq.org
+shortname: 15/ZMTP
+name: ZeroMQ Message Transport Protocol
+status: deprecated
+editor: Pieter Hintjens <ph@imatix.com>
+contributors:
+  - Martin Hurton <mh@imatix.com>
+  - Paul Colomiets <paul@colomiets.name>
+---
 
-* Name: http://rfc.zeromq.org/spec:15/ZMTP
-* Editor: Pieter Hintjens <ph@imatix.com>
-* Contributors: Martin Hurton <mh@imatix.com>, Paul Colomiets <paul@colomiets.name>
+The ZeroMQ Message Transport Protocol (ZMTP) is a transport layer protocol for exchanging messages between two peers over a connected transport layer such as TCP. This document describes ZMTP/2.0.
 
 ## License
 
@@ -145,4 +152,3 @@ If an implementation does not want backwards compatibility with ZMTP/1.0 peers, 
 ## Security
 
 ZMTP/2.0 makes no attempt at security, which an application MAY layer on top.
-

--- a/16/README.md
+++ b/16/README.md
@@ -1,7 +1,12 @@
-The Collective Code Construction Contract (C4) is an evolution of the github.com [Fork + Pull Model](http://help.github.com/send-pull-requests/), aimed at providing an optimal collaboration model for free software projects. C4 is derived from the ZeroMQ contribution policy of early 2012.
+---
+domain: rfc.zeromq.org
+shortname: 16/C4
+name: Collective Code Construction Contract (C4)
+status: retired
+editor: Pieter Hintjens <ph@imatix.com>
+---
 
-* Name: http://rfc.zeromq.org/spec:16/C4
-* Editor: Pieter Hintjens <ph@imatix.com>
+The Collective Code Construction Contract (C4) is an evolution of the github.com [Fork + Pull Model](http://help.github.com/send-pull-requests/), aimed at providing an optimal collaboration model for free software projects. C4 is derived from the ZeroMQ contribution policy of early 2012.
 
 Note: this RFC is superceded by [rfc.zeromq.org/spec:22/C4.1](http://rfc.zeromq.org/spec:22).
 
@@ -150,4 +155,3 @@ C4 is meant to provide a reusable optimal collaboration model for open source so
 * Old names SHALL NOT be reused by new features.
 
 * When old names are removed, their implementations MUST provoke an exception (assertion) if used by applications.
-

--- a/17/README.md
+++ b/17/README.md
@@ -1,8 +1,14 @@
-The ZeroMQ Device Configuration File (ZDCF) specifies a standard language for configuring 0MQ devices. It provides information to configure a 0MQ context, and a set of 0MQ sockets. This specification aims to make it easier to build, share, and reuse 0MQ devices and build systems for device administration.
+---
+domain: rfc.zeromq.org
+shortname: 17/ZDCF
+name: ZeroMQ Device Configuration File
+status: stable
+editor: Pieter Hintjens <ph@imatix.com>
+contributors:
+  - Steffen Mueller <smueller@cpan.org>
+---
 
-* Name: http://rfc.zeromq.org/spec:17/ZDCF
-* Editor: Pieter Hintjens <ph@imatix.com>
-* Contributors: Steffen Mueller <smueller@cpan.org>
+The ZeroMQ Device Configuration File (ZDCF) specifies a standard language for configuring 0MQ devices. It provides information to configure a 0MQ context, and a set of 0MQ sockets. This specification aims to make it easier to build, share, and reuse 0MQ devices and build systems for device administration.
 
 ## License
 
@@ -232,4 +238,3 @@ A software that consumes ZDCF content must adhere to the following rules:
 * It shall not accept any ZDCF content that was written against a specification with a greater integer version than what the ZDCF-consuming software was written to accept.
 
 In other words, you are free to implement backwards-compatibility with older versions of the specification, but please don't silently try to accept content that was written against a specification that you did not implement. Your users will thank you for it. If at the time of implementation, the specification version that you had access to is 5.3, then you may accept content written against 5.4 assuming it's a specification change that is backwards compatible. ZDCF 6.0, however, you should reject until you've updated your implementation to handle it.
-

--- a/18/README.md
+++ b/18/README.md
@@ -1,8 +1,15 @@
-The Majordomo Protocol (MDP) defines a reliable service-oriented request-reply dialog between a set of client applications, a broker and a set of worker applications. MDP covers presence, heartbeating, and service-oriented request-reply processing. It originated from the Majordomo pattern defined in Chapter 4 of the Guide. This is MDP version 0.2, which adds support for multiple replies for a single request.
+---
+domain: rfc.zeromq.org
+shortname: 18/MDP
+name:  Majordomo Protocol
+status: draft
+editor: Pieter Hintjens <ph@imatix.com>
+contributors:
+  - Chuck Remes <cremes@mac.com>
+  - Guido Goldstein <zmqdev@a-nugget.de>
+---
 
-* Name: http://rfc.zeromq.org/spec:18/MDP
-* Editor: Pieter Hintjens <ph@imatix.com>
-* Contributors: Chuck Remes <cremes@mac.com>, Guido Goldstein <zmqdev@a-nugget.de>
+The Majordomo Protocol (MDP) defines a reliable service-oriented request-reply dialog between a set of client applications, a broker and a set of worker applications. MDP covers presence, heartbeating, and service-oriented request-reply processing. It originated from the Majordomo pattern defined in Chapter 4 of the Guide. This is MDP version 0.2, which adds support for multiple replies for a single request.
 
 ## License
 

--- a/19/README.md
+++ b/19/README.md
@@ -1,7 +1,12 @@
-The File Message Queuing Protocol (FILEMQ) governs the delivery of files between a 'client' and a 'server'. FILEMQ runs over the ZeroMQ [ZMTP protocol](http://rfc.zeromq.org/spec:15/ZMTP).
+---
+domain: rfc.zeromq.org
+shortname: 19/FILEMQ
+name: File Message Queuing Protocol
+status: retired
+editor: Pieter Hintjens <ph@imatix.com>
+---
 
-* Name: http://rfc.zeromq.org/spec:19/FILEMQ
-* Editor: Pieter Hintjens <ph@imatix.com>
+The File Message Queuing Protocol (FILEMQ) governs the delivery of files between a 'client' and a 'server'. FILEMQ runs over the ZeroMQ [ZMTP protocol](http://rfc.zeromq.org/spec:15/ZMTP).
 
 ## License
 
@@ -213,4 +218,3 @@ The server SHALL respond to an invalid command by sending RTFM. Note that the se
 ## Security Aspects
 
 FILEMQ uses the Simple Authentication and Security Layer (SASL) for authentication and encryption. The SHA-1 digest used for file cache identification has no security implications.
-

--- a/2/README.md
+++ b/2/README.md
@@ -1,7 +1,11 @@
-SPB is a minimalist format for framing opaque binary blobs.  The blobs have no properties and no content structure, and are represented as a size field followed by a blob content.
+---
+domain: rfc.zeromq.org
+shortname: 2/SPB
+status: deprecated
+editor: Pieter Hintjens <ph@imatix.com>
+---
 
-* Name: http://rfc.zeromq.org/spec:2/SPB
-* Editor: Pieter Hintjens <ph@imatix.com>
+SPB is a minimalist format for framing opaque binary blobs.  The blobs have no properties and no content structure, and are represented as a size field followed by a blob content.
 
 ## License
 
@@ -71,4 +75,3 @@ data       = *OCTET
 ## Reference implementation
 
 A reference implementation for SPB can be found in the [0MQ](http://www.zeromq.org) project.
-

--- a/20/README.md
+++ b/20/README.md
@@ -1,7 +1,12 @@
-The ZeroMQ Realtime Exchange Protocol (ZRE) governs how a group of peers on a network discover each other, organize into groups, and send each other events. ZRE runs over the ZeroMQ [ZMTP protocol](http://rfc.zeromq.org/spec:15/ZMTP). Note that this specification has been superceded by rfc.zeromq.org/spec:36/ZRE.
+---
+domain: rfc.zeromq.org
+shortname: 20/ZRE
+name: ZeroMQ Realtime Exchange Protocol
+status: retired
+editor: Pieter Hintjens <ph@imatix.com>
+---
 
-* Name: http://rfc.zeromq.org/spec:20/ZRE
-* Editor: Pieter Hintjens <ph@imatix.com>
+The ZeroMQ Realtime Exchange Protocol (ZRE) governs how a group of peers on a network discover each other, organize into groups, and send each other events. ZRE runs over the ZeroMQ [ZMTP protocol](http://rfc.zeromq.org/spec:15/ZMTP). Note that this specification has been superceded by rfc.zeromq.org/spec:36/ZRE.
 
 ## Preamble
 

--- a/21/README.md
+++ b/21/README.md
@@ -1,7 +1,12 @@
-The C Language Style for Scalability (CLASS) defines a consistent style and organization for scalable C library and application code built on modern C compilers and operating systems. CLASS aims to collect industry best practice into one reusable standard.
+---
+domain: rfc.zeromq.org
+shortname: 21/CLASS
+name: C Language Style for Scalability
+status: stable
+editor: Pieter Hintjens <ph@imatix.com>
+---
 
-* Name: http://rfc.zeromq.org/spec:21/CLASS
-* Editor: Pieter Hintjens <ph@imatix.com>
+The C Language Style for Scalability (CLASS) defines a consistent style and organization for scalable C library and application code built on modern C compilers and operating systems. CLASS aims to collect industry best practice into one reusable standard.
 
 ## License
 

--- a/22/README.md
+++ b/22/README.md
@@ -1,7 +1,12 @@
-The Collective Code Construction Contract (C4) is an evolution of the github.com [Fork + Pull Model](http://help.github.com/send-pull-requests/), aimed at providing an optimal collaboration model for free software projects. This is revision 1 of the C4 specification.
+---
+domain: rfc.zeromq.org
+shortname: 22/C4
+name: Collective Code Construction Contract (C4)
+status: deprecated
+editor: Pieter Hintjens <ph@imatix.com>
+---
 
-* Name: http://rfc.zeromq.org/spec:22/C4
-* Editor: Pieter Hintjens <ph@imatix.com>
+The Collective Code Construction Contract (C4) is an evolution of the github.com [Fork + Pull Model](http://help.github.com/send-pull-requests/), aimed at providing an optimal collaboration model for free software projects. This is revision 1 of the C4 specification.
 
 Note: this RFC is superceded by http://rfc.zeromq.org/spec:42/C4
 

--- a/23/README.md
+++ b/23/README.md
@@ -1,8 +1,15 @@
-The ZeroMQ Message Transport Protocol (ZMTP) is a transport layer protocol for exchanging messages between two peers over a connected transport layer such as TCP. This document describes ZMTP 3.0. The major change in this version is the addition of security mechanisms and the removal of hard-coded connection metadata (socket type and identity) from the greeting.
+---
+domain: rfc.zeromq.org
+shortname: 23/ZMTP
+name: ZeroMQ Message Transport Protocol
+status: stable
+editor: Pieter Hintjens <ph@imatix.com>
+contributors:
+  - Martin Hurton <mh@imatix.com>
+  - Ian Barber <ian.barber@gmail.com>
+---
 
-* Name: http://rfc.zeromq.org/spec:23/ZMTP
-* Editor: Pieter Hintjens <ph@imatix.com>
-* Contributors: Martin Hurton <mh@imatix.com>, Ian Barber <ian.barber@gmail.com>
+The ZeroMQ Message Transport Protocol (ZMTP) is a transport layer protocol for exchanging messages between two peers over a connected transport layer such as TCP. This document describes ZMTP 3.0. The major change in this version is the addition of security mechanisms and the removal of hard-coded connection metadata (socket type and identity) from the greeting.
 
 ## Preamble
 

--- a/24/README.md
+++ b/24/README.md
@@ -1,8 +1,14 @@
+---
+domain: rfc.zeromq.org
+shortname: 24/ZMTP-PLAIN
+name: ZMTP PLAIN
+status: stable
+editor: Pieter Hintjens <ph@imatix.com>
+---
+
 The ZMTP PLAIN mechanism defines a simple username/password mechanism for [ZMTP 3.0](http://rfc.zeromq.org/spec:23) that lets a server authenticate a client. PLAIN makes no attempt at security or confidentiality. It is intended for use on internal networks where security requirements are low.
 
-* Name: http://rfc.zeromq.org/spec:24/ZMTP-PLAIN
-* Editor: Pieter Hintjens <ph@imatix.com>
-* See also: http://rfc.zeromq.org/spec:23/ZMTP.
+See also: http://rfc.zeromq.org/spec:23/ZMTP.
 
 ## Preamble
 

--- a/25/README.md
+++ b/25/README.md
@@ -1,8 +1,14 @@
+---
+domain: rfc.zeromq.org
+shortname: 25/ZMTP-CURVE
+name: ZMTP CURVE
+status: stable
+editor: Pieter Hintjens <ph@imatix.com>
+---
+
 The ZMTP CURVE mechanism provides secure authentication and confidentiality for [ZMTP 3.0](http://rfc.zeromq.org/spec:23). This mechanism implements the [CurveZMQ security protocol](http://curvezmq.org). It is intended for use on public networks where security requirements are high.
 
-* Name: http://rfc.zeromq.org/spec:25/ZMTP-CURVE
-* Editor: Pieter Hintjens <ph@imatix.com>
-* See also: http://rfc.zeromq.org/spec:23/ZMTP, http://rfc.zeromq.org/spec:24/ZMTP-PLAIN.
+See also: http://rfc.zeromq.org/spec:23/ZMTP, http://rfc.zeromq.org/spec:24/ZMTP-PLAIN.
 
 ## Preamble
 

--- a/26/README.md
+++ b/26/README.md
@@ -1,8 +1,14 @@
+---
+domain: rfc.zeromq.org
+shortname: 26/CURVEZMQ
+name: CurveZMQ
+status: stable
+editor: Pieter Hintjens <ph@imatix.com>
+---
+
 This document describes CurveZMQ, a protocol for secure messaging across the Internet. CurveZMQ is closely based on Daniel J. Bernstein's [CurveCP](http://curvecp.org), adapted for use in ZeroMQ over TCP. A reference implementation of CurveZMQ is provided at [curvezmq.org](http://curvezmq.org). This document describes version 1.0 of CurveZMQ.
 
-* Name: http://rfc.zeromq.org/spec:26/CURVEZMQ
-* Editor: Pieter Hintjens <ph@imatix.com>
-* See also: http://rfc.zeromq.org/spec:23/ZMTP, http://rfc.zeromq.org/spec:25/ZMTP-CURVE.
+See also: http://rfc.zeromq.org/spec:23/ZMTP, http://rfc.zeromq.org/spec:25/ZMTP-CURVE.
 
 ## Preamble
 

--- a/27/README.md
+++ b/27/README.md
@@ -1,8 +1,14 @@
+---
+domain: rfc.zeromq.org
+shortname: 27/ZAP
+name: ZeroMQ Authentication Protocol
+status: stable
+editor: Pieter Hintjens <ph@imatix.com>
+---
+
 This document specifies ZAP, the ZeroMQ Authentication Protocol. The use case for ZAP is a set of *servers* that need authentication of remote clients, and which talk to an *handler* that checks client credentials. ZAP defines how the servers connect to the handler, and the messages they exchange.
 
-* Name: http://rfc.zeromq.org/spec:27/ZAP
-* Editor: Pieter Hintjens <ph@imatix.com>
-* See also: http://rfc.zeromq.org/spec:23/ZMTP, http://rfc.zeromq.org/spec:24/ZMTP-NULL, http://rfc.zeromq.org/spec:24/ZMTP-PLAIN, http://rfc.zeromq.org/spec:25/ZMTP-CURVE, http://rfc.zeromq.org/spec:26/CURVEZMQ.
+See also: http://rfc.zeromq.org/spec:23/ZMTP, http://rfc.zeromq.org/spec:24/ZMTP-NULL, http://rfc.zeromq.org/spec:24/ZMTP-PLAIN, http://rfc.zeromq.org/spec:25/ZMTP-CURVE, http://rfc.zeromq.org/spec:26/CURVEZMQ.
 
 ## Preamble
 

--- a/28/README.md
+++ b/28/README.md
@@ -1,7 +1,12 @@
-This document specifies the semantics of the ZeroMQ request-reply pattern, which covers the REQ, REP, DEALER, and ROUTER socket types. This specification is intended to guide implementations of these socket types so that users can depend on reliable semantics.
+---
+domain: rfc.zeromq.org
+shortname: 28/REQREP
+name: ZeroMQ Request-Reply
+status: stable
+editor: Pieter Hintjens <ph@imatix.com>
+---
 
-* Name: http://rfc.zeromq.org/spec:28/REQREP
-* Editor: Pieter Hintjens <ph@imatix.com>
+This document specifies the semantics of the ZeroMQ request-reply pattern, which covers the REQ, REP, DEALER, and ROUTER socket types. This specification is intended to guide implementations of these socket types so that users can depend on reliable semantics.
 
 ## Preamble
 

--- a/29/README.md
+++ b/29/README.md
@@ -1,7 +1,12 @@
-This document specifies the semantics of the ZeroMQ publish-subscribe pattern, which covers the PUB, XPUB, SUB, and XSUB socket types. This specification is intended to guide implementations of these socket types so that users can depend on reliable semantics.
+---
+domain: rfc.zeromq.org
+shortname: 29/PUBSUB
+name: ZeroMQ Publish-Subscribe
+status: stable
+editor: Pieter Hintjens <ph@imatix.com>
+---
 
-* Name: http://rfc.zeromq.org/spec:29/PUBSUB
-* Editor: Pieter Hintjens <ph@imatix.com>
+This document specifies the semantics of the ZeroMQ publish-subscribe pattern, which covers the PUB, XPUB, SUB, and XSUB socket types. This specification is intended to guide implementations of these socket types so that users can depend on reliable semantics.
 
 ## Preamble
 

--- a/3/README.md
+++ b/3/README.md
@@ -1,7 +1,12 @@
-The ZeroMQ Device Configuration File format (ZDCF) specifies a standard syntax for configuring 0MQ devices.  It provides information to configure a 0MQ context, and a set of 0MQ sockets.  This specification aims to make it easier to share and reuse devices and build systems for device administration.
+---
+domain: rfc.zeromq.org
+shortname: 3/ZDCF
+name: ZeroMQ Device Configuration File
+status: retired
+editor: Pieter Hintjens <ph@imatix.com>
+---
 
-* Name: http://rfc.zeromq.org/spec:3/zdcf
-* Editor: Pieter Hintjens <ph@imatix.com>
+The ZeroMQ Device Configuration File format (ZDCF) specifies a standard syntax for configuring 0MQ devices.  It provides information to configure a 0MQ context, and a set of 0MQ sockets.  This specification aims to make it easier to share and reuse devices and build systems for device administration.
 
 ## License
 
@@ -138,4 +143,3 @@ The built-in device types that exist at time of writing are:
 * "zstreamer" - ZMQ_STREAMER
 
 See [zmq_device(3)](http://api.zeromq.org/zmq_device.html) for details.
-

--- a/30/README.md
+++ b/30/README.md
@@ -1,7 +1,12 @@
-This document specifies the semantics of the ZeroMQ pipeline pattern, which covers the PUSH and PULL socket types. This specification is intended to guide implementations of these socket types so that users can depend on reliable semantics.
+---
+domain: rfc.zeromq.org
+shortname: 30/PIPELINE
+name: ZeroMQ Pipeline
+status: stable
+editor: Pieter Hintjens <ph@imatix.com>
+---
 
-* Name: http://rfc.zeromq.org/spec:30/PIPELINE
-* Editor: Pieter Hintjens <ph@imatix.com>
+This document specifies the semantics of the ZeroMQ pipeline pattern, which covers the PUSH and PULL socket types. This specification is intended to guide implementations of these socket types so that users can depend on reliable semantics.
 
 ## Preamble
 

--- a/31/README.md
+++ b/31/README.md
@@ -1,7 +1,12 @@
-This document specifies the semantics of the ZeroMQ exclusive pair pattern, which covers the PAIR socket type. This specification is intended to guide implementations of this socket type so that users can depend on reliable semantics.
+---
+domain: rfc.zeromq.org
+shortname: 31/EXPAIR
+name: ZeroMQ Exclusive Pair
+status: stable
+editor: Pieter Hintjens <ph@imatix.com>
+---
 
-* Name: http://rfc.zeromq.org/spec:31/EXPAIR
-* Editor: Pieter Hintjens <ph@imatix.com>
+This document specifies the semantics of the ZeroMQ exclusive pair pattern, which covers the PAIR socket type. This specification is intended to guide implementations of this socket type so that users can depend on reliable semantics.
 
 ## Preamble
 

--- a/32/README.md
+++ b/32/README.md
@@ -1,7 +1,11 @@
-This document specifies Z85, a format for representing binary data as printable text. Z85 is a derivative of existing [Ascii85 encoding mechanisms](http://en.wikipedia.org/wiki/Ascii85), modified for better usability, particularly for use in source code.
+---
+domain: rfc.zeromq.org
+shortname: 32/Z85
+status: stable
+editor: Pieter Hintjens <ph@imatix.com>
+---
 
-* Name: http://rfc.zeromq.org/spec:32/Z85
-* Editor: Pieter Hintjens <ph@imatix.com>
+This document specifies Z85, a format for representing binary data as printable text. Z85 is a derivative of existing [Ascii85 encoding mechanisms](http://en.wikipedia.org/wiki/Ascii85), modified for better usability, particularly for use in source code.
 
 ## Preamble
 

--- a/33/README.md
+++ b/33/README.md
@@ -1,7 +1,12 @@
-This document describes a protocol for performing HTTP requests and responses over ZeroMQ. It is partly modeled after the protocols of Mongrel2 and ZeroGW, but with the addition of streaming capability and credits-based flow control.
+---
+domain: rfc.zeromq.org
+shortname: 33/ZHTTP
+name: HTTP requests and responses over ZeroMQ
+status: stable
+editor: Justin Karneges <justin@fanout.io>
+---
 
-* Name: http://rfc.zeromq.org/spec:33/ZHTTP
-* Editor: Justin Karneges <justin@fanout.io>
+This document describes a protocol for performing HTTP requests and responses over ZeroMQ. It is partly modeled after the protocols of Mongrel2 and ZeroGW, but with the addition of streaming capability and credits-based flow control.
 
 ## License
 
@@ -159,4 +164,3 @@ If both sides attempt to start a handoff at the same time, then this is a tie an
 ### Reference Implementations
 
 Zurl (see "[Zurl](http://github.com/fanout/zurl)") is the prime preference implementation for ZHTTP. It translates incoming ZHTTP requests into outgoing HTTP requests.
-

--- a/34/README.md
+++ b/34/README.md
@@ -1,8 +1,13 @@
+---
+domain: rfc.zeromq.org
+shortname: 34/SRPZMQ
+status: stable
+editor: Diego Duclos <diego.duclos@palmstonegames.com>
+---
+
 This document describes an extension of the ZMQ security mechanism to be able to authenticate a client without the client having to have a private key generated beforehand. Instead, keys are generated from a pregenerated private key on the server side (which have been generated during some kind of registration process) and from a username/password combination on the client side.
 
-* Name: http://rfc.zeromq.org/spec:34/SRPZMQ
-* Editor: Diego Duclos <diego.duclos@palmstonegames.com>
-* See also: http://pythonhosted.org/srp/srp.html#srp-6a-protocol-description, http://srp.stanford.edu/.
+See also: http://pythonhosted.org/srp/srp.html#srp-6a-protocol-description, http://srp.stanford.edu/.
 
 ## Preamble
 

--- a/35/README.md
+++ b/35/README.md
@@ -1,7 +1,12 @@
-The File Message Queuing Protocol (FILEMQ) governs the delivery of files between a 'client' and a 'server'. FILEMQ runs over the ZeroMQ [ZMTP v3 protocol](http://rfc.zeromq.org/spec:23/ZMTP). This is version 2 of the FILEMQ protocol.
+---
+domain: rfc.zeromq.org
+shortname: 35/FILEMQ
+name: File Message Queuing Protocol
+status: draft
+editor: Pieter Hintjens <ph@imatix.com>
+---
 
-* Name: http://rfc.zeromq.org/spec:35/FILEMQ
-* Editor: Pieter Hintjens <ph@imatix.com>
+The File Message Queuing Protocol (FILEMQ) governs the delivery of files between a 'client' and a 'server'. FILEMQ runs over the ZeroMQ [ZMTP v3 protocol](http://rfc.zeromq.org/spec:23/ZMTP). This is version 2 of the FILEMQ protocol.
 
 ## Preamble
 

--- a/36/README.md
+++ b/36/README.md
@@ -1,7 +1,12 @@
-The ZeroMQ Realtime Exchange Protocol (ZRE) governs how a group of peers on a network discover each other, organize into groups, and send each other events. ZRE runs over the [ZeroMQ Message Transfer Protocol (ZMTP)](http://rfc.zeromq.org/spec:23/ZMTP).
+---
+domain: rfc.zeromq.org
+shortname: 36/ZRE
+name: ZeroMQ Realtime Exchange Protocol
+status: draft
+editor: Pieter Hintjens <ph@imatix.com>
+---
 
-* Name: http://rfc.zeromq.org/spec:36/ZRE
-* Editor: Pieter Hintjens <ph@imatix.com>
+The ZeroMQ Realtime Exchange Protocol (ZRE) governs how a group of peers on a network discover each other, organize into groups, and send each other events. ZRE runs over the [ZeroMQ Message Transfer Protocol (ZMTP)](http://rfc.zeromq.org/spec:23/ZMTP).
 
 ## Preamble
 

--- a/37/README.md
+++ b/37/README.md
@@ -1,7 +1,12 @@
-The ZeroMQ Message Transport Protocol (ZMTP) is a transport layer protocol for exchanging messages between two peers over a connected transport layer such as TCP. This document describes ZMTP 3.1. This version adds SUBSCRIBE, CANCEL, PING and PONG commands, and endpoint resources.
+---
+domain: rfc.zeromq.org
+shortname: 37/ZMTP
+name: ZeroMQ Realtime Exchange Protocol
+status: draft
+editor: Pieter Hintjens <ph@imatix.com>
+---
 
-* Name: http://rfc.zeromq.org/spec:37/ZMTP
-* Editor: Pieter Hintjens <ph@imatix.com>
+The ZeroMQ Message Transport Protocol (ZMTP) is a transport layer protocol for exchanging messages between two peers over a connected transport layer such as TCP. This document describes ZMTP 3.1. This version adds SUBSCRIBE, CANCEL, PING and PONG commands, and endpoint resources.
 
 ## Preamble
 
@@ -616,4 +621,3 @@ This draft is open for discussion. The following topics at least are still on th
 * Credits, as a signaling mechanism for asynchronous flow control. This allows fine control over the amount of queued data. In this scenario, the receiving peer (DEALER, PULL, REP) would send credit which would be used up by messages routed to it. The minimal use-case is for PUSH/DEALER-to-PULL/DEALER round-robin routing. Credit could be octets, or messages.
 
 * Commands or other strategies to allow wire analysis on unencrypted networks (without some additional information it is not possible to determine when messages start).
-

--- a/38/README.md
+++ b/38/README.md
@@ -1,8 +1,14 @@
+---
+domain: rfc.zeromq.org
+shortname: 38/ZMTP-GSSAPI
+name: ZMTP GSSAPI
+status: draft
+editor: Chris Busbey <cbusbey@connamara.com>
+---
+
 The ZMTP GSSAPI mechanism provides secure authentication and confidentiality for [ZMTP 3.0](http://rfc.zeromq.org/spec:23). This mechanism utilizes the [Generic Security Service Application Interface](http://tools.ietf.org/html/rfc2743).
 
-* Name: http://rfc.zeromq.org/spec:38/ZMTP-GSSAPI
-* Editor: Chris Busbey <cbusbey@connamara.com>
-* See also: http://tools.ietf.org/html/rfc2743
+See also: http://tools.ietf.org/html/rfc2743
 
 ## Preamble
 

--- a/39/README.md
+++ b/39/README.md
@@ -1,8 +1,12 @@
-The ZeroMQ WebSocket (ZWS) protocol is a mapping for ZeroMQ over WebSocket.
+---
+domain: rfc.zeromq.org
+shortname: 39/ZWS
+name: ZeroMQ WebSocket
+status: stable
+editor: Doron Somech <somdoron@gmail.com>
+---
 
-* Name: http://rfc.zeromq.org/spec:39/ZWTP
-* Editor: Doron Somech <somdoron@gmail.com>
-* Contributors:
+The ZeroMQ WebSocket (ZWS) protocol is a mapping for ZeroMQ over WebSocket.
 
 ## Language
 
@@ -134,4 +138,3 @@ However the protocol can be tunneled over SSL.
 Clients support tunnel over SSL with specifying wss instead of ws, for example "wss://example.com".
 
 Load balancer might terminate the SSL before arriving on the server.
-

--- a/4/README.md
+++ b/4/README.md
@@ -1,7 +1,12 @@
-The ZeroMQ Property Language (ZPL) defines a minimalistic framing language for specifying property sets, expressed as a hierarchy of name-value property pairs.
+---
+domain: rfc.zeromq.org
+shortname: 4/ZPL
+name: ZeroMQ Property Language
+status: stable
+editor: Pieter Hintjens <ph@imatix.com>
+---
 
-* Name: http://rfc.zeromq.org/spec:4/ZPL
-* Editor: Pieter Hintjens <ph@imatix.com>
+The ZeroMQ Property Language (ZPL) defines a minimalistic framing language for specifying property sets, expressed as a hierarchy of name-value property pairs.
 
 ## License
 
@@ -101,4 +106,3 @@ ZPL exists because alternatives were inadequate:
 The use of significant whitespace may be controversial. It is meant to be easier to create and verify manually than syntax elements such as braces. It eliminates the need for separators. The fixed 4-character indentation is meant to avoid confusion and errors when fragments of ZPL files from different sources are mixed together.
 
 The lack of type awareness and other semantic validation is deliberate. ZPL is not meant to be a formal grammar but a simple-to-parse framing for name/value pairs. It emulates 0MQ insofar as it frames data but does not attempt to inspect or validate that data.
-

--- a/40/README.md
+++ b/40/README.md
@@ -1,7 +1,12 @@
-This document describes the Extensible Resource Access Protocol (XRAP), a RESTful protocol built over ZeroMQ. XRAP provides a single, extensible answer to the problem of how to work with remote resources. We designed XRAP to avert the development of fragile domain-specific RPC protocols.
+---
+domain: rfc.zeromq.org
+shortname: 40/XRAP
+name:  Extensible Resource Access Protocol
+status: stable
+editor: Pieter Hintjens <ph@imatix.com>
+---
 
-* Name: http://rfc.zeromq.org/spec:40/XRAP
-* Contributors: Pieter Hintjens <ph@imatix.com>
+This document describes the Extensible Resource Access Protocol (XRAP), a RESTful protocol built over ZeroMQ. XRAP provides a single, extensible answer to the problem of how to work with remote resources. We designed XRAP to avert the development of fragile domain-specific RPC protocols.
 
 ## Preamble
 

--- a/41/README.md
+++ b/41/README.md
@@ -1,7 +1,11 @@
-This document specifies the semantics of the ZeroMQ request-reply pattern, which covers the CLIENT and SERVER socket types. This specification is intended to guide implementations of these socket types so that users can depend on reliable semantics.
+---
+domain: rfc.zeromq.org
+shortname: 41/CLISRV
+status: draft
+editor: Pieter Hintjens <ph@imatix.com>
+---
 
-* Name: http://rfc.zeromq.org/spec:41/CLISRV
-* Editor: Pieter Hintjens <ph@imatix.com>
+This document specifies the semantics of the ZeroMQ request-reply pattern, which covers the CLIENT and SERVER socket types. This specification is intended to guide implementations of these socket types so that users can depend on reliable semantics.
 
 ## Preamble
 

--- a/42/README.md
+++ b/42/README.md
@@ -1,7 +1,12 @@
-The Collective Code Construction Contract (C4) is an evolution of the github.com [Fork + Pull Model](http://help.github.com/send-pull-requests/), aimed at providing an optimal collaboration model for free software projects. This is revision 2 of the C4 specification and deprecates RFC 22.
+---
+domain: rfc.zeromq.org
+shortname: 42/C4
+name: Collective Code Construction Contract
+status: stable
+editor: Pieter Hintjens <ph@imatix.com>
+---
 
-* Name: http://rfc.zeromq.org/spec:42/C4
-* Editor: Pieter Hintjens <ph@imatix.com>
+The Collective Code Construction Contract (C4) is an evolution of the github.com [Fork + Pull Model](http://help.github.com/send-pull-requests/), aimed at providing an optimal collaboration model for free software projects. This is revision 2 of the C4 specification and deprecates RFC 22.
 
 ## License
 

--- a/5/README.md
+++ b/5/README.md
@@ -1,7 +1,12 @@
-The ZeroMQ Device Configuration File (ZDCF) specifies a standard language for configuring 0MQ devices. It provides information to configure a 0MQ context, and a set of 0MQ sockets. This specification aims to make it easier to build, share, and reuse 0MQ devices and build systems for device administration.
+---
+domain: rfc.zeromq.org
+shortname: 5/ZDCF
+name: ZeroMQ Device Configuration File
+status: retired
+editor: Pieter Hintjens <ph@imatix.com>
+---
 
-* Name: http://rfc.zeromq.org/spec:5/ZDCF
-* Editor: Pieter Hintjens <ph@imatix.com>
+The ZeroMQ Device Configuration File (ZDCF) specifies a standard language for configuring 0MQ devices. It provides information to configure a 0MQ context, and a set of 0MQ sockets. This specification aims to make it easier to build, share, and reuse 0MQ devices and build systems for device administration.
 
 ## License
 
@@ -186,4 +191,3 @@ For example:
         "bind": [ "tcp://eth0:5555", "inproc://device" ]
     }
 ```
-

--- a/6/README.md
+++ b/6/README.md
@@ -1,7 +1,12 @@
-The Paranoid Pirate Protocol (PPP) defines a reliable request-reply dialog between a client (or client) and a worker peer. PPP covers presence, heartbeating, and request-reply processing. It originated in Chapter 4 of the Guide.
+---
+domain: rfc.zeromq.org
+shortname: 6/PPP
+name: Paranoid Pirate Protocol
+status: stable
+editor: Pieter Hintjens <ph@imatix.com>
+---
 
-* Name: http://rfc.zeromq.org/spec:6/PPP
-* Editor: Pieter Hintjens <ph@imatix.com>
+The Paranoid Pirate Protocol (PPP) defines a reliable request-reply dialog between a client (or client) and a worker peer. PPP covers presence, heartbeating, and request-reply processing. It originated in Chapter 4 of the Guide.
 
 ## License
 
@@ -82,4 +87,3 @@ Peers should send heartbeats at regular and agreed-upon intervals. A peer can co
 If the worker detects that the client has disconnected, it MUST send READY again to start a new conversation.
 
 If the client detects that the worker has disconnected, it SHOULD stop sending it messages of any type.
-

--- a/7/README.md
+++ b/7/README.md
@@ -1,8 +1,15 @@
-The Majordomo Protocol (MDP) defines a reliable service-oriented request-reply dialog between a set of client applications, a broker and a set of worker applications. MDP covers presence, heartbeating, and service-oriented request-reply processing. It originated from the Majordomo pattern defined in Chapter 4 of the Guide.
+---
+domain: rfc.zeromq.org
+shortname: 7/MDP
+name: Majordomo Protocol
+status: deprecated
+editor: Pieter Hintjens <ph@imatix.com>
+contributors:
+  - Chuck Remes <cremes@mac.com>
+  - Guido Goldstein <zmqdev@a-nugget.de>
+---
 
-* Name: http://rfc.zeromq.org/spec:7/MDP
-* Editor: Pieter Hintjens <ph@imatix.com>
-* Contributors: Chuck Remes <cremes@mac.com>, Guido Goldstein <zmqdev@a-nugget.de>
+The Majordomo Protocol (MDP) defines a reliable service-oriented request-reply dialog between a set of client applications, a broker and a set of worker applications. MDP covers presence, heartbeating, and service-oriented request-reply processing. It originated from the Majordomo pattern defined in Chapter 4 of the Guide.
 
 ## License
 

--- a/8/README.md
+++ b/8/README.md
@@ -1,7 +1,12 @@
-The Majordomo Management Interface (MMI) defines a namespace and set of management services that MDP brokers may provide. MMI is layered on top of the 7/MDP protocol.
+---
+domain: rfc.zeromq.org
+shortname: 8/MMI
+name: Majordomo Management Interface
+status: stable
+editor: Pieter Hintjens <ph@imatix.com>
+---
 
-* Name: http://rfc.zeromq.org/spec:8/MMI
-* Editor: Pieter Hintjens <ph@imatix.com>
+The Majordomo Management Interface (MMI) defines a namespace and set of management services that MDP brokers may provide. MMI is layered on top of the 7/MDP protocol.
 
 ## License
 
@@ -47,4 +52,3 @@ Any unimplemented services in the "mmi." namespace MUST result in a reply "501" 
 ### Reference Implementations
 
 The C99 Majordomo examples from Chapter 4 of the Guide (see "[ØMQ - The Guide](http://zguide.zeromq.org)") act as the prime reference implementation for MMI. Translations of the examples into other languages may be available.
-

--- a/9/README.md
+++ b/9/README.md
@@ -1,7 +1,12 @@
-The Titanic Service Protocol (SP) defines a set of services, requests, and replies that implement the Titanic pattern for disconnected persistent messaging across a network of arbitrarily connected clients and workers.
+---
+domain: rfc.zeromq.org
+shortname: 9/TSP
+name: Titanic Service Protocol
+status: stable
+editor: Pieter Hintjens <ph@imatix.com>
+---
 
-* Name: http://rfc.zeromq.org/spec:9/TSP
-* Editor: Pieter Hintjens <ph@imatix.com>
+The Titanic Service Protocol (TSP) defines a set of services, requests, and replies that implement the Titanic pattern for disconnected persistent messaging across a network of arbitrarily connected clients and workers.
 
 ## License
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -34,10 +34,10 @@
   * [32/Z85](32/README.md)
   * [33/ZHTTP](33/README.md)
   * [34/SRPZMQ](34/README.md)
-  * [39/ZWTP](39/README.md)
+  * [39/ZWS](39/README.md)
   * [40/XRAP](40/README.md)
   * [42/C4](42/README.md)
-* Legacy
+* Deprecated
   * [1/SPB](1/README.md)
   * [2/SPB](2/README.md)
   * [7/MDP](7/README.md)
@@ -50,8 +50,3 @@
   * [16/C4](16/README.md)
   * [19/FILEMQ](19/README.md)
   * [20/ZRE](20/README.md)
-
-
-
-
-

--- a/book.js
+++ b/book.js
@@ -1,5 +1,5 @@
 module.exports = {
     title: 'ZeroMQ RFCs',
     gitbook: '>=3.0.0',
-    plugins: ['coss@1.0.4']
+    plugins: ['coss@1.0.5']
 };


### PR DESCRIPTION
Solution: use latest COSS draft's YAML recommendation

gitbook-plugin-coss 1.0.5 uses YAML front matter to generate
standard headers, color coded badges and titles.

GitHub is also aware of YAML front matter and renders it in Markdown
documents.