### PR TITLE
Problem: hard to find the latest version of a given spec

### DIFF
--- a/book.js
+++ b/book.js
@@ -1,5 +1,5 @@
 module.exports = {
     title: 'ZeroMQ RFCs',
     gitbook: '>=3.0.0',
-    plugins: ['coss@1.0.5']
+    plugins: ['coss@1.0.6']
 };


### PR DESCRIPTION
Solution: new COSS plugin creates a shortcut for the shortname

For example /C4, or /ZMTP

This way, for example, http://rfc.zeromq.com/C4 will point to the last "actionable" version.