### PR TITLE
Problem: New urls are incompatiable with old ones

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,4 +7,4 @@ theme = "book"
 BookMenuBundle = "/menu"
 
 [permalinks]
-  docs = "/spec/:title"
+  docs = "/spec/:slug"

--- a/content/docs/rfcs/1/README.md
+++ b/content/docs/rfcs/1/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 1
 title: 1/SPB
 aliases: [/spec:1/SPB]
 status: deprecated

--- a/content/docs/rfcs/10/README.md
+++ b/content/docs/rfcs/10/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 10
 title: 10/FLP
 aliases: [/spec:10/FLP]
 name: Freelance Protocol

--- a/content/docs/rfcs/11/README.md
+++ b/content/docs/rfcs/11/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 11
 title: 11/MTL
 aliases: [/spec:11/MTL]
 name: Message Transport Layer

--- a/content/docs/rfcs/12/README.md
+++ b/content/docs/rfcs/12/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 12
 title: 12/CHP
 aliases: [/spec:12/CHP]
 name: Clustered Hashmap Protocol

--- a/content/docs/rfcs/13/README.md
+++ b/content/docs/rfcs/13/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 13
 title: 13/ZMTP
 aliases: [/spec:13/ZMTP]
 name: ZeroMQ Message Transport Protocol

--- a/content/docs/rfcs/14/README.md
+++ b/content/docs/rfcs/14/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 14
 title: 14/WMP
 aliases: [ "/spec:14/WMP" ]
 name: Worker-Manager Protocol

--- a/content/docs/rfcs/15/README.md
+++ b/content/docs/rfcs/15/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 15
 title: 15/ZMTP
 aliases: [/spec:15/ZMTP]
 name: ZeroMQ Message Transport Protocol

--- a/content/docs/rfcs/16/README.md
+++ b/content/docs/rfcs/16/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 16
 title: 16/C4
 aliases: [/spec:16/C4]
 name: Collective Code Construction Contract (C4)

--- a/content/docs/rfcs/17/README.md
+++ b/content/docs/rfcs/17/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 17
 title: 17/ZDCF
 aliases: [/spec:17/ZDCF]
 name: ZeroMQ Device Configuration File

--- a/content/docs/rfcs/18/README.md
+++ b/content/docs/rfcs/18/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 18
 title: 18/MDP
 aliases: [/spec:18/MDP]
 name:  Majordomo Protocol

--- a/content/docs/rfcs/19/README.md
+++ b/content/docs/rfcs/19/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 19
 title: 19/FILEMQ
 aliases: [/spec:19/FILEMQ]
 name: File Message Queuing Protocol

--- a/content/docs/rfcs/2/README.md
+++ b/content/docs/rfcs/2/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 2
 title: 2/SPB
 aliases: [/spec:2/SPB]
 status: deprecated

--- a/content/docs/rfcs/20/README.md
+++ b/content/docs/rfcs/20/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 20
 title: 20/ZRE
 aliases: [/spec:20/ZRE]
 name: ZeroMQ Realtime Exchange Protocol

--- a/content/docs/rfcs/21/README.md
+++ b/content/docs/rfcs/21/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 21
 title: 21/CLASS
 aliases: [/spec:21/CLASS]
 name: C Language Style for Scalability

--- a/content/docs/rfcs/22/README.md
+++ b/content/docs/rfcs/22/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 22
 title: 22/C4
 aliases: [/spec:22/C4]
 name: Collective Code Construction Contract (C4)

--- a/content/docs/rfcs/23/README.md
+++ b/content/docs/rfcs/23/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 23
 title: 23/ZMTP
 aliases: [/spec:23/ZMTP]
 name: ZeroMQ Message Transport Protocol

--- a/content/docs/rfcs/24/README.md
+++ b/content/docs/rfcs/24/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 24
 title: 24/ZMTP-PLAIN
 aliases: [/spec:24/ZMTP-PLAIN]
 name: ZMTP PLAIN

--- a/content/docs/rfcs/25/README.md
+++ b/content/docs/rfcs/25/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 25
 title: 25/ZMTP-CURVE
 aliases: [/spec:25/ZMTP-CURVE]
 name: ZMTP CURVE

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 26
 title: 26/CURVEZMQ
 aliases: [/spec:26/CURVEZMQ]
 name: CurveZMQ

--- a/content/docs/rfcs/27/README.md
+++ b/content/docs/rfcs/27/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 27
 title: 27/ZAP
 aliases: [/spec:27/ZAP]
 name: ZeroMQ Authentication Protocol

--- a/content/docs/rfcs/28/README.md
+++ b/content/docs/rfcs/28/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 28
 title: 28/REQREP
 aliases: [/spec:28/REQREP]
 name: ZeroMQ Request-Reply

--- a/content/docs/rfcs/29/README.md
+++ b/content/docs/rfcs/29/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 29
 title: 29/PUBSUB
 aliases: [/spec:29/PUBSUB]
 name: ZeroMQ Publish-Subscribe

--- a/content/docs/rfcs/3/README.md
+++ b/content/docs/rfcs/3/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 3
 title: 3/ZDCF
 aliases: [/spec:3/ZDCF]
 name: ZeroMQ Device Configuration File

--- a/content/docs/rfcs/30/README.md
+++ b/content/docs/rfcs/30/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 30
 title: 30/PIPELINE
 aliases: [/spec:30/PIPELINE]
 name: ZeroMQ Pipeline

--- a/content/docs/rfcs/31/README.md
+++ b/content/docs/rfcs/31/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 31
 title: 31/EXPAIR
 aliases: [/spec:31/EXPAIR]
 name: ZeroMQ Exclusive Pair

--- a/content/docs/rfcs/32/README.md
+++ b/content/docs/rfcs/32/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 32
 title: 32/Z85
 aliases: [/spec:32/Z85]
 status: stable

--- a/content/docs/rfcs/33/README.md
+++ b/content/docs/rfcs/33/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 33
 title: 33/ZHTTP
 aliases: [/spec:33/ZHTTP]
 name: HTTP requests and responses over ZeroMQ

--- a/content/docs/rfcs/34/README.md
+++ b/content/docs/rfcs/34/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 34
 title: 34/SRPZMQ
 aliases: [/spec:34/SRPZMQ]
 status: stable

--- a/content/docs/rfcs/35/README.md
+++ b/content/docs/rfcs/35/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 35
 title: 35/FILEMQ
 aliases: [/spec:35/FILEMQ]
 name: File Message Queuing Protocol

--- a/content/docs/rfcs/36/README.md
+++ b/content/docs/rfcs/36/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 36
 title: 36/ZRE
 aliases: [/spec:36/ZRE]
 name: ZeroMQ Realtime Exchange Protocol

--- a/content/docs/rfcs/37/README.md
+++ b/content/docs/rfcs/37/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 37
 title: 37/ZMTP
 aliases: [/spec:37/ZMTP]
 name: ZeroMQ Realtime Exchange Protocol

--- a/content/docs/rfcs/38/README.md
+++ b/content/docs/rfcs/38/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 38
 title: 38/ZMTP-GSSAPI
 aliases: [/spec:38/ZMTP-GSSAPI]
 name: ZMTP GSSAPI

--- a/content/docs/rfcs/39/README.md
+++ b/content/docs/rfcs/39/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 39
 title: 39/ZWS
 aliases: [/spec:39/ZWS]
 name: ZeroMQ WebSocket

--- a/content/docs/rfcs/4/README.md
+++ b/content/docs/rfcs/4/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 4
 title: 4/ZPL
 aliases: [/spec:4/ZPL]
 name: ZeroMQ Property Language

--- a/content/docs/rfcs/40/README.md
+++ b/content/docs/rfcs/40/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 40
 title: 40/XRAP
 aliases: [/spec:40/XRAP]
 name:  Extensible Resource Access Protocol

--- a/content/docs/rfcs/41/README.md
+++ b/content/docs/rfcs/41/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 41
 title: 41/CLISRV
 aliases: [/spec:41/CLISRV]
 status: draft

--- a/content/docs/rfcs/42/README.md
+++ b/content/docs/rfcs/42/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 42
 title: 42/C4
 aliases: [/spec:42/C4]
 name: Collective Code Construction Contract

--- a/content/docs/rfcs/43/README.md
+++ b/content/docs/rfcs/43/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 43
 title: 43/ZRE
 aliases: [/spec:43/ZRE]
 name: ZeroMQ Realtime Exchange Protocol

--- a/content/docs/rfcs/44/README.md
+++ b/content/docs/rfcs/44/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 44
 title: 44/C4
 aliases: [/spec:44/C4]
 name: Collective Code Construction Contract

--- a/content/docs/rfcs/45/README.md
+++ b/content/docs/rfcs/45/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 45
 title: 45/ZWS
 name: ZeroMQ WebSocket Protocol 2.0
 aliases: [/spec:45/ZWS]

--- a/content/docs/rfcs/5/README.md
+++ b/content/docs/rfcs/5/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 5
 title: 5/ZDCF
 aliases: [/spec:5/ZDCF]
 name: ZeroMQ Device Configuration File

--- a/content/docs/rfcs/6/README.md
+++ b/content/docs/rfcs/6/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 6
 title: 6/PPP
 aliases: [/spec:6/PPP]
 name: Paranoid Pirate Protocol

--- a/content/docs/rfcs/7/README.md
+++ b/content/docs/rfcs/7/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 7
 title: 7/MDP
 aliases: [/spec:7/MDP]
 name: Majordomo Protocol

--- a/content/docs/rfcs/8/README.md
+++ b/content/docs/rfcs/8/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 8
 title: 8/MMI
 aliases: [/spec:8/MMI]
 name: Majordomo Management Interface

--- a/content/docs/rfcs/9/README.md
+++ b/content/docs/rfcs/9/README.md
@@ -1,4 +1,5 @@
 ---
+slug: 9
 title: 9/TSP
 aliases: [/spec:9/TSP]
 name: Titanic Service Protocol

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,3 +10,9 @@ command = "make preview-build"
 
 [context.branch-deploy]
 command = "make preview-build"
+
+[[redirects]]
+from = "/spec:*"
+to = "/spec/:splat"
+status = 200
+force = true


### PR DESCRIPTION
Solution: Instead of /spec/<no>/<shortname> use just /spec/<no>