### PR TITLE
Problem: Multiple definition of Client-Server pattern

### DIFF
--- a/content/docs/rfcs/41/README.md
+++ b/content/docs/rfcs/41/README.md
@@ -1,11 +1,12 @@
 ---
 slug: 41
-title: 41/CLISRV
-status: draft
-editor: Pieter Hintjens <ph@imatix.com>
+title: 41/CLIENTSERVER
+name: ZeroMQ Client-Server
+status: Draft
+editor: Pieter Hintjens <ph@imatix.com>; Doron Somech <somdoron@gmail.com>
 ---
 
-This document specifies the semantics of the ZeroMQ request-reply pattern, which covers the CLIENT and SERVER socket types. This specification is intended to guide implementations of these socket types so that users can depend on reliable semantics.
+This document specifies the semantics of the ZeroMQ client-server pattern, which covers the CLIENT and SERVER socket types. This specification is intended to guide implementations of these socket types so that users can depend on reliable semantics.
 
 ## Preamble
 
@@ -13,7 +14,7 @@ Copyright (c) 2015 iMatix Corporation.
 
 This Specification is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 3 of the License, or (at your option) any later version. This Specification is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with this program; if not, see <http://www.gnu.org/licenses>.
 
-This Specification is a [free and open standard](http://www.digistan.org/open-standard:definition) and is governed by the Digital Standards Organization"s [Consensus-Oriented Specification System](http://www.digistan.org/spec:1/COSS).
+This Specification is a [free and open standard](http://www.digistan.org/open-standard:definition) and is governed by the Digital Standards Organization's [Consensus-Oriented Specification System](http://www.digistan.org/spec:1/COSS).
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
 
@@ -23,13 +24,20 @@ This specification is intended to formally document the names and expected behav
 
 ## Overall Goals of this Pattern
 
-The client-server pattern is intended for service-oriented architectures of various kinds. It provides an asynchronous two-way message flow between a CLIENT and a SERVER socket. All flows are initiated by the CLIENT. A flow consists of at least one request, followed by zero or more replies. The CLIENT-SERVER pattern is a building block for higher-level protocols.
+Client-server pattern is member of a new family of thread-safe sockets.
+It is the thread-safe alternative of the router-dealer pattern.
+The client-server pattern is intended for service-oriented architectures of various kinds and is asynchronous, like the router-dealer pattern.
+It provides an asynchronous two-way message flow between a CLIENT and a SERVER socket.
+All flows are initiated by the CLIENT.
+The CLIENT-SERVER pattern is a building block for higher-level protocols.
+
+In order for the API to be thread-safe sending and receiving messages MUST be atomic and a single API call to receive or send entire msg. Therefore, the client-server pattern (and the rest of the thread-safe family) MUST NOT allow multipart messages.
 
 This pattern is meant to deprecate and eventually replace the request-reply pattern.
 
 ## The CLIENT Socket Type
 
-The CLIENT socket type talks to one or more SERVER peers. If connected to multiple peers, it scatters sent messages among these peers in a round-robin fashion. On reading, it reads fairly, from each peer in turn. It is reliable, insofar as it does not drop messages in normal cases.
+The CLIENT socket type talks to a set of SERVER peers, sending and receiving messages using round-robin algorithms. It is reliable, insofar as it does not drop messages.
 
 General behavior:
 
@@ -39,47 +47,53 @@ General behavior:
 * SHALL create a double queue when initiating an outgoing connection to a peer, and SHALL maintain the double queue whether or not the connection is established.
 * SHALL create a double queue when a peer connects to it. If this peer disconnects, the CLIENT socket SHALL destroy its double queue and SHALL discard any messages it contains.
 * SHOULD constrain incoming and outgoing queue sizes to a runtime-configurable limit.
+* MUST be thread-safe and allow receiving and sending from multiple threads.
 
 For processing outgoing messages:
 
-* SHALL consider a peer as available only when it has a outgoing queue that is not full.
+* SHALL consider a peer as available only when it has a not full outgoing queue.
 * SHALL route outgoing messages to available peers using a round-robin strategy.
 * SHALL block on sending, or return a suitable error, when it has no available peers.
-* SHALL not accept further messages when it has no available peers.
 * SHALL NOT discard messages that it cannot queue.
+* MUST NOT send multipart messages.
 
 For processing incoming messages:
 
 * SHALL receive incoming messages from its peers using a fair-queuing strategy.
 * SHALL deliver these to its calling application.
+* MUST discard any part of a multipart message
+* MAY disconnect a peer that is sending multipart messages.
 
 ## The SERVER Socket Type
 
-The SERVER socket type talks to zero or more CLIENT peers. Each outgoing message is sent to a specific peer CLIENT.
+The SERVER socket type talks to a set of CLIENT peers, using an explicit routing-id so that each outgoing message is sent to a specific peer CLIENT.
 
 General behavior:
 
 * MAY be connected to any number of CLIENT peers, and MAY both send and receive messages.
-* SHALL not filter or modify outgoing or incoming messages in any way.
 * SHALL maintain a double queue for each connected peer, allowing outgoing and incoming messages to be queued independently.
 * SHALL create a double queue when initiating an outgoing connection to a peer, and SHALL maintain the double queue whether or not the connection is established.
 * SHALL create a double queue when a peer connects to it. If this peer disconnects, the SERVER socket SHALL destroy its double queue and SHALL discard any messages it contains.
-* SHALL identify each double queue using a unique "routing id", which is a non-zero 32-bit unsigned integer value.
+* SHALL assign a routing-id to each double queue.
+* Routing-id SHALL be 4-bytes integer.
+* SHALL NOT allow the peer to specify its routing id explicitly.
 * SHOULD constrain incoming and outgoing queue sizes to a runtime-configurable limit.
 
 For processing incoming messages:
 
 * SHALL receive incoming messages from its peers using a fair-queuing strategy.
+* SHALL attach the routing-id of the double queue to the message.
 * SHALL deliver the resulting messages to its calling application.
-* SHALL provide the application with an API to retrieve the message routing-id.
+* MUST discard any part of a multipart message
+* MAY disconnect a peer that is sending multipart messages.
 
 For processing outgoing messages:
 
-* SHALL provide the application with an API to set the message routing-id.
+* SHALL remove the first frame from each outgoing message and use this as the identity of a double queue.
 * SHALL route the message to the outgoing queue if that queue exists, and is not full.
-* SHALL return an error if the queue does not exist.
-* SHALL block on sending, if the queue is full, unless otherwise configured.
-* SHALL NOT discard messages that it cannot queue.
+* SHALL either silently drop the message or return an error, depending on configuration, if the queue does not exist, or is full.
+* SHALL NOT block on sending.
+* MUST NOT send multi-part messages.
 
 ## Security Aspects
 

--- a/content/menu/index.md
+++ b/content/menu/index.md
@@ -11,12 +11,11 @@ bookMenuLevels: 1
   * [35/FILEMQ]({{< relref "/docs/rfcs/35/README.md" >}})
   * [37/ZMTP]({{< relref "/docs/rfcs/37/README.md" >}})
   * [38/ZMTP-GSSAPI]({{< relref "/docs/rfcs/38/README.md" >}})
-  * [41/CLISRV]({{< relref "/docs/rfcs/41/README.md" >}})
+  * [41/CLIENTSERVER]({{< relref "/docs/rfcs/41/README.md" >}})
   * [43/ZYREv3]({{< relref "/docs/rfcs/43/README.md" >}})
   * [44/C4]({{< relref "/docs/rfcs/44/README.md" >}})
   * [45/ZWS]({{< relref "/docs/rfcs/45/README.md" >}})
   * [46/DAFKA]({{< relref "/docs/rfcs/46/README.md" >}})
-  * [47/CLIENTSERVER]({{< relref "/docs/rfcs/47/README.md" >}})
   * [48/RADIODISH]({{< relref "/docs/rfcs/48/README.md" >}})
   * [49/SCATTERGATHER]({{< relref "/docs/rfcs/49/README.md" >}})
 * Stable
@@ -57,3 +56,4 @@ bookMenuLevels: 1
   * [16/C4]({{< relref "/docs/rfcs/16/README.md" >}})
   * [19/FILEMQ]({{< relref "/docs/rfcs/19/README.md" >}})
   * [20/ZRE]({{< relref "/docs/rfcs/20/README.md" >}})
+  * [47/CLIENTSERVER]({{< relref "/docs/rfcs/47/README.md" >}})


### PR DESCRIPTION
Solution: Merge content of both RFC in a single one

This is an attempt to solve issue #152.

I kept the least recent one, that is RFC 41, but updated it with content from the RFC 47 that made sense to me.
There was some wording and I noted 2 main differences.

1. RFC 47 forbid multi-part messages
This seemed relevant for the Thread-Safe part of the pattern.
I do not master the ZeroMQ mysteries and maybe this is already dealt with how sockets receives messages, which seems to be an all or nothing from the user point of view.
Since it defines new sockets, I was not sure and kept it.

2. RFC 41 Block on sending from SERVER side
Since the SERVER will communicate with multiple CLIENTs, it seemed better to discard messages on full queue and not blocking sending in this case.