### PR TITLE
Problem: RFC 37/ZMTP metadata name typo

### DIFF
--- a/content/docs/rfcs/37/README.md
+++ b/content/docs/rfcs/37/README.md
@@ -1,7 +1,7 @@
 ---
 slug: 37
 title: 37/ZMTP
-name: ZeroMQ Realtime Exchange Protocol
+name: ZeroMQ Message Transport Protocol
 status: draft
 editor: Pieter Hintjens <ph@imatix.com>
 ---


### PR DESCRIPTION
Solution: Fix specification name in the metadata

Solves https://github.com/zeromq/rfc/issues/176