### PR TITLE
Problem: Branch name uses Non-inclusive language

### DIFF
--- a/content/docs/rfcs/44/README.md
+++ b/content/docs/rfcs/44/README.md
@@ -97,7 +97,7 @@ C4 is meant to provide a reusable optimal collaboration model for open source so
 
 ### 2.5. Branches and Releases
 
-1. The project SHALL have one branch ("master") that always holds the latest in-progress version and SHOULD always build.
+1. The project SHALL have one branch ("main", or historically "master") that always holds the latest in-progress version and SHOULD always build.
 1. The project SHALL NOT use topic branches for any reason. Personal forks MAY use topic branches.
 1. To make a stable release a Maintainer SHALL tag the repository. Stable releases SHALL always be released from the repository master.
 


### PR DESCRIPTION
Solutions:
* Use new default GitHub name
* leave "master" as historical name

Solves #186